### PR TITLE
Alternative line numbering and comment fix.

### DIFF
--- a/ruby-one-liners/Readme.md
+++ b/ruby-one-liners/Readme.md
@@ -106,7 +106,7 @@ for each of these tasks:
     ruby -ne 'puts $_ unless $_ == "\n"'
 
 
-### delete consecutive duplicate lines from file
+### delete consecutive empty lines (all but one in each group) from file
 
     ruby -ne 'puts $_ if /^[^\n]/../^$/'
 

--- a/ruby-one-liners/Readme.md
+++ b/ruby-one-liners/Readme.md
@@ -17,6 +17,11 @@ for each of these tasks:
       # (also, 1.9 only)
       ruby -e 'l=-> line {puts "#$. #{line}"}; ARGV.each { |name| File.foreach name, &l}; $stdin.each &l'
 
+      # alternative version
+      # $<.pos, that is ARGF#pos, returns position (in bytes) in the current file
+      # that allows us to reset $. at the end of the first line of each file
+      ruby -ne '$. = 1 if $<.pos - $_.size == 0; puts "#$. #$_"'
+
 
 ### add line numbers for all files together
 


### PR DESCRIPTION
Added alternative version for line numbering per file. It might have issues with multi-byte encoding as `ARGF#pos` returns position in bytes. To work properly in that cases `String#bytesize` can be used instead of regular `String#size`.

In addition fixed comment for removing consecutive blank lines. I was thinking for a while how that can remove consecutive duplicate lines and finally realized that you speaking about blank lines.
